### PR TITLE
Add FastAPI TikTok clone example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+videos/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Mini TikTok Clone
+
+This project is a simple demonstration of how you might implement a TikTok-like API using [FastAPI](https://fastapi.tiangolo.com/).
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the development server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+## API Endpoints
+
+- `POST /users` – Create a new user. Body: `{"username": "example"}`
+- `POST /videos` – Upload a video. Form field `file` (video) and JSON body containing `user_id` and optional `description`.
+- `GET /feed` – Retrieve the list of uploaded videos.
+- `GET /videos/{video_id}` – Download a specific video file.
+
+Uploaded files are stored in the `videos/` directory.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from uuid import uuid4
+import os
+
+app = FastAPI(title="Mini TikTok Clone")
+
+# Data storage
+USERS = {}
+VIDEOS = {}
+VIDEO_DIR = "videos"
+os.makedirs(VIDEO_DIR, exist_ok=True)
+
+class UserCreate(BaseModel):
+    username: str
+
+
+@app.post("/users")
+async def create_user(user: UserCreate):
+    user_id = str(uuid4())
+    USERS[user_id] = {"id": user_id, "username": user.username}
+    return USERS[user_id]
+
+@app.post("/videos")
+async def upload_video(
+    user_id: str = Form(...),
+    description: str = Form(""),
+    file: UploadFile = File(...),
+):
+    if user_id not in USERS:
+        raise HTTPException(status_code=404, detail="User not found")
+    video_id = str(uuid4())
+    file_ext = os.path.splitext(file.filename)[1]
+    file_path = os.path.join(VIDEO_DIR, f"{video_id}{file_ext}")
+    with open(file_path, "wb") as buffer:
+        buffer.write(await file.read())
+    VIDEOS[video_id] = {
+        "id": video_id,
+        "user_id": user_id,
+        "description": description,
+        "filename": file_path,
+    }
+    return VIDEOS[video_id]
+
+@app.get("/feed")
+async def feed():
+    return list(VIDEOS.values())
+
+@app.get("/videos/{video_id}")
+async def get_video(video_id: str):
+    video = VIDEOS.get(video_id)
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+    return FileResponse(video["filename"], media_type="video/mp4")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -s

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+python-multipart

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,34 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_create_user():
+    resp = client.post("/users", json={"username": "alice"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "id" in data
+    assert data["username"] == "alice"
+
+def test_upload_video_and_feed(tmp_path):
+    # create user
+    user_resp = client.post("/users", json={"username": "bob"})
+    user_id = user_resp.json()["id"]
+
+    # create a dummy video file
+    video_file = tmp_path / "video.mp4"
+    video_file.write_bytes(b"0" * 10)
+
+    with video_file.open("rb") as f:
+        resp = client.post(
+            "/videos",
+            data={"user_id": user_id, "description": "test"},
+            files={"file": ("video.mp4", f, "video/mp4")},
+        )
+    assert resp.status_code == 200
+    video_id = resp.json()["id"]
+
+    feed_resp = client.get("/feed")
+    assert feed_resp.status_code == 200
+    assert any(v["id"] == video_id for v in feed_resp.json())


### PR DESCRIPTION
## Summary
- add simple FastAPI app implementing a small TikTok-style API
- create tests for user creation and video upload endpoints
- document setup and usage in README
- add requirements and gitignore

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5fcf97a0833394c3604e103d6459