### PR TITLE
Add basic HTML front end

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This project is a simple demonstration of how you might implement a TikTok-like 
    uvicorn app.main:app --reload
    ```
 
+Then open `http://localhost:8000/` in your browser to use a minimal web
+interface for creating users, uploading videos and browsing the feed.
+
 ## API Endpoints
 
 - `POST /users` – Create a new user. Body: `{"username": "example"}`

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,12 @@
-from fastapi import FastAPI, UploadFile, File, Form, HTTPException
-from fastapi.responses import FileResponse
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 from uuid import uuid4
 import os
 
 app = FastAPI(title="Mini TikTok Clone")
+templates = Jinja2Templates(directory="app/templates")
 
 # Data storage
 USERS = {}
@@ -14,6 +16,11 @@ os.makedirs(VIDEO_DIR, exist_ok=True)
 
 class UserCreate(BaseModel):
     username: str
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse(request, "index.html")
 
 
 @app.post("/users")

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mini TikTok Clone</title>
+</head>
+<body>
+    <h1>Mini TikTok Clone</h1>
+    <h2>Create User</h2>
+    <form id="user-form">
+        <input type="text" name="username" placeholder="Username" required>
+        <button type="submit">Create</button>
+    </form>
+    <h2>Upload Video</h2>
+    <form id="video-form" enctype="multipart/form-data">
+        <input type="text" name="user_id" placeholder="User ID" required><br>
+        <input type="text" name="description" placeholder="Description"><br>
+        <input type="file" name="file" accept="video/*" required><br>
+        <button type="submit">Upload</button>
+    </form>
+    <h2>Feed</h2>
+    <button id="refresh-feed">Refresh Feed</button>
+    <ul id="feed"></ul>
+<script>
+async function createUser(event) {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const resp = await fetch('/users', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({username: formData.get('username')})
+    });
+    const data = await resp.json();
+    alert('Created user with id: ' + data.id);
+}
+async function uploadVideo(event) {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const resp = await fetch('/videos', {
+        method: 'POST',
+        body: formData
+    });
+    const data = await resp.json();
+    alert('Uploaded video with id: ' + data.id);
+}
+async function refreshFeed() {
+    const resp = await fetch('/feed');
+    const data = await resp.json();
+    const feedEl = document.getElementById('feed');
+    feedEl.innerHTML = '';
+    for (const vid of data) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = '/videos/' + vid.id;
+        a.innerText = vid.description || vid.id;
+        li.appendChild(a);
+        feedEl.appendChild(li);
+    }
+}
+document.getElementById('user-form').addEventListener('submit', createUser);
+document.getElementById('video-form').addEventListener('submit', uploadVideo);
+document.getElementById('refresh-feed').addEventListener('click', refreshFeed);
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 python-multipart
+jinja2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,11 @@ from app.main import app
 
 client = TestClient(app)
 
+def test_index_page():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
 def test_create_user():
     resp = client.post("/users", json={"username": "alice"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- serve a web interface at `/` using Jinja2 templates
- implement HTML page to create users, upload videos and view feed
- document the website usage
- test that the index page loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f613d45988333bad065883cb75993